### PR TITLE
Exposes JagLink/ComLynx UART to USERIO port

### DIFF
--- a/Jaguar.sv
+++ b/Jaguar.sv
@@ -182,9 +182,15 @@ module emu
 ///////// Default values for ports not used in this core /////////
 
 assign ADC_BUS  = 'Z;
-assign USER_OUT = '1;
 assign {UART_RTS, UART_TXD, UART_DTR} = 0;
 assign {SD_SCK, SD_MOSI, SD_CS} = 'Z;
+
+assign USER_OUT[0] = 1'b1;
+assign USER_OUT[2] = 1'b1;
+assign USER_OUT[3] = 1'b1;
+assign USER_OUT[4] = 1'b1;
+assign USER_OUT[5] = 1'b1;
+assign USER_OUT[6] = 1'b1;
 
 assign VGA_SL = 0;
 assign VGA_F1 = 0;
@@ -253,6 +259,7 @@ localparam CONF_STR = {
 	"O78,Aspect ratio,Original,Full Screen,[ARC1],[ARC2];",
 	"O9A,Scandoubler Fx,None,HQ2x,CRT 25%,CRT 50%,CRT 75%;",
 	"O56,Mouse,Disabled,JoyPort1,JoyPort2;",
+	"OB,JagLink,Disabled,Enabled;",
 	"O3,CPU Speed,Normal,Turbo;",
 	"OE,VSync,vvs,hvs(debug);",
 	"RF,Reset RAM(debug);",
@@ -469,6 +476,11 @@ wire startcas;
 wire [15:0] aud_16_l;
 wire [15:0] aud_16_r;
 
+wire ser_data_in;
+wire ser_data_out;
+assign ser_data_in = status[11] ? USER_IN[0] : 1'b1;
+assign USER_OUT[1] = status[11] ? ser_data_out : 1'b1;
+
 jaguar jaguar_inst
 (
 	.xresetl_in( xresetl ) ,	// input  xresetl
@@ -538,7 +550,10 @@ jaguar jaguar_inst
 	.ps2_mouse( ps2_mouse ) ,
 
 	.mouse_ena_1( status[6:5]==1 ) ,
-	.mouse_ena_2( status[6:5]==2 )
+	.mouse_ena_2( status[6:5]==2 ) ,
+
+	.comlynx_tx( ser_data_out ) ,
+	.comlynx_rx( ser_data_in )
 );
 
 

--- a/Jaguar.sv
+++ b/Jaguar.sv
@@ -239,7 +239,7 @@ assign VIDEO_ARY = (!ar) ? 12'd2040 : 12'd0;
 // 0         1         2         3          4         5         6
 // 01234567890123456789012345678901 23456789012345678901234567890123
 // 0123456789ABCDEFGHIJKLMNOPQRSTUV 0123456789ABCDEFGHIJKLMNOPQRSTUV
-// X XXXXXXXXXXXXXXX
+// X XXXXXXXXXXXXXXXX
 
 //
 
@@ -259,7 +259,7 @@ localparam CONF_STR = {
 	"O78,Aspect ratio,Original,Full Screen,[ARC1],[ARC2];",
 	"O9A,Scandoubler Fx,None,HQ2x,CRT 25%,CRT 50%,CRT 75%;",
 	"O56,Mouse,Disabled,JoyPort1,JoyPort2;",
-	"OB,JagLink,Disabled,Enabled;",
+	"OH,JagLink,Disabled,Enabled;",
 	"O3,CPU Speed,Normal,Turbo;",
 	"OE,VSync,vvs,hvs(debug);",
 	"RF,Reset RAM(debug);",
@@ -478,8 +478,8 @@ wire [15:0] aud_16_r;
 
 wire ser_data_in;
 wire ser_data_out;
-assign ser_data_in = status[11] ? USER_IN[0] : 1'b1;
-assign USER_OUT[1] = status[11] ? ser_data_out : 1'b1;
+assign ser_data_in = status[17] ? USER_IN[0] : 1'b1;
+assign USER_OUT[1] = status[17] ? ser_data_out : 1'b1;
 
 jaguar jaguar_inst
 (

--- a/rtl/Rework/jaguar.v
+++ b/rtl/Rework/jaguar.v
@@ -62,6 +62,9 @@ module jaguar
 
 	input               mouse_ena_1,
 	input               mouse_ena_2,
+	
+	output              comlynx_tx,
+	input               comlynx_rx,
 
 	output              startcas,
 
@@ -92,6 +95,9 @@ assign dram_startwep = startwep;
 wire os_rom_ce_n;
 wire os_rom_oe_n;
 wire os_rom_oe = (~os_rom_ce_n & ~os_rom_oe_n);	// os_rom_oe feeds back TO the core, to enable the internal drivers.
+
+assign j_xserin = comlynx_rx;
+assign comlynx_tx = j_xserout;
 
 // Note: Turns out the custom chips use synchronous resets.
 // So these clocks need to be left running during reset, else the core won't start up correctly the next time the HPS resets it. ElectronAsh.
@@ -354,7 +360,7 @@ assign j_xpclkin = j_xpclkout;
 assign j_xdbgl = xdbgl;                 // Bus Grant from Tom
 assign j_xoel_0 = xoel[0];              // Output Enable
 assign j_xwel_0 = xwel[0];              // Write Enable
-assign j_xserin = 1'b1;
+
 assign j_xdtackl = xdtackl;             // Data Acknowledge from Tom (also goes to the 68K)
 assign j_xi2srxd = 1'b1;                // (Async?) I2S receive
 assign j_xeint[0] = 1'b1;               // External Interrupt


### PR DESCRIPTION
Exposes JagLink/ComLynx UART to USERIO port

USERIO Pin 0 is RX
USERIO Pin 1 is TX

TestUART homebrew works with homemade JagLink to RS232 cable.  

![jaglink-snac](https://github.com/user-attachments/assets/53ede68c-cbac-4ad4-b2db-6e3f778cf464)

My copycat JagLink SNAC hardware appears to work. I'm able to use the TestUART ROM to send a character and it responds with the next character as described in the documentation. If you send an 'a' you get a 'b' returned for instance. However, it only works once and you need to reset the core to try again. Looking at the source to TestUART it looks like it should continue to run and respond to characters received.

None of the games are working at the moment. I have logic captures from each game trying to connect. What I noticed is only 1-2 bytes are sent from one or both Jaguar cores before TX is stuck low.

Aircars: The game fails unable to find another player.

BattleSphere/BattleSphere Gold: Unable to find another player, however, it seems to 'sense' the other MiSTer. 

Doom: Locks up when looking for other players with or without my patch when trying to do multiplayer. The Option button should return you to the main menu.

Behind Jaggy Lines Bios (v1.06.d): UART game dumper when started(Button 6) produces an exception shortly after starting and spits out a couple of bytes over Jaglink. The exception varies but here is one example.
![BJD-Exception](https://github.com/user-attachments/assets/2ef613b1-9013-4b7e-9e2d-d169d90544f4)

In SignalTap after the byte is sent it seems to sit in the register. I'm wondering if this is exposing a bug as all software exhibits the same behavior.

[TestUART.zip](https://github.com/user-attachments/files/18220020/TestUART.zip)

[Jaguar_DS_JagLink_20250120.rbf.zip](https://github.com/user-attachments/files/18496900/Jaguar_DS_JagLink_20250120.rbf.zip)
