### PR TITLE
Team Tap Support

### DIFF
--- a/Jaguar.sv
+++ b/Jaguar.sv
@@ -239,7 +239,7 @@ assign VIDEO_ARY = (!ar) ? 12'd2040 : 12'd0;
 // 0         1         2         3          4         5         6
 // 01234567890123456789012345678901 23456789012345678901234567890123
 // 0123456789ABCDEFGHIJKLMNOPQRSTUV 0123456789ABCDEFGHIJKLMNOPQRSTUV
-// X XXXXXXXXXXXXXXXXXXXXX XXXXXXXX                     XXXXX     XX
+// X XXXXXXXXXXXXXXX XXXXX XXXXXXXX XX                  XXXXX     XX
 
 `include "build_id.v"
 localparam CONF_STR = {
@@ -276,7 +276,7 @@ localparam CONF_STR = {
 	"O56,Mouse,Disabled,JoyPort1,JoyPort2;",
 	"OKL,Spinner Speed,Normal,Faster,Slow,Slower;",
 	"RM,P1+P2 Pause;",
-	"OH,Team Tap,Disabled,Enabled;",
+	"o01,Team Tap,Disabled,JoyPort1,JoyPort2;",
 	"-;",
 	"-Options may crash;",
 	"RF,Reset RAM(debug);",
@@ -619,7 +619,8 @@ jaguar jaguar_inst
 	.spinner_0(spinner_0),
 	.spinner_1(spinner_1),
 	.spinner_speed(status[21:20]),
-	.team_tap_port2( status[17] ),
+	.team_tap_port1( status[33:32]==1 ),
+	.team_tap_port2( status[33:32]==2 ),
 
 	.startcas( startcas ) ,
 

--- a/Jaguar.sv
+++ b/Jaguar.sv
@@ -276,7 +276,7 @@ localparam CONF_STR = {
 	"O56,Mouse,Disabled,JoyPort1,JoyPort2;",
 	"OKL,Spinner Speed,Normal,Faster,Slow,Slower;",
 	"RM,P1+P2 Pause;",
-	"OH,JagLink,Disabled,Enabled;",
+	"OH,Team Tap,Disabled,Enabled;",
 	"-;",
 	"-Options may crash;",
 	"RF,Reset RAM(debug);",
@@ -299,6 +299,9 @@ wire [63:0] status;
 wire  [1:0] buttons;
 wire [31:0] joystick_0;
 wire [31:0] joystick_1;
+wire [31:0] joystick_2;
+wire [31:0] joystick_3;
+wire [31:0] joystick_4;
 wire        ioctl_download;
 wire        ioctl_wr;
 wire [24:0] ioctl_addr;
@@ -343,6 +346,9 @@ hps_io #(.CONF_STR(CONF_STR), .PS2DIV(1000), .WIDE(1)) hps_io
 
 	.joystick_0(joystick_0),
 	.joystick_1(joystick_1),
+	.joystick_2(joystick_2),
+	.joystick_3(joystick_3),
+	.joystick_4(joystick_4),
 	.joystick_l_analog_0(analog_0),
 	.joystick_l_analog_1(analog_1),
 
@@ -544,8 +550,8 @@ wire [15:0] aud_16_r;
 
 wire ser_data_in;
 wire ser_data_out;
-assign ser_data_in = status[17] ? USER_IN[0] : 1'b1;
-assign USER_OUT[1] = status[17] ? ser_data_out : 1'b1;
+assign ser_data_in = USER_IN[0];
+assign USER_OUT[1] = ser_data_out;
 
 jaguar jaguar_inst
 (
@@ -603,6 +609,9 @@ jaguar jaguar_inst
 
 	.joystick_0( {joystick_0[31:9], joystick_0[8]|p1p2pause_active,joystick_0[7:0]} ) ,
 	.joystick_1( {joystick_1[31:9], joystick_1[8]|p1p2pause_active,joystick_1[7:0]} ) ,
+	.joystick_2( {joystick_2[31:9], joystick_2[8]|p1p2pause_active,joystick_2[7:0]} ) ,
+	.joystick_3( {joystick_3[31:9], joystick_3[8]|p1p2pause_active,joystick_3[7:0]} ) ,
+	.joystick_4( {joystick_4[31:9], joystick_4[8]|p1p2pause_active,joystick_4[7:0]} ) ,
 	.analog_0( $signed(analog_0[7:0]) + 9'sd127 ),
 	.analog_1( $signed(analog_0[15:8]) + 9'sd127 ),
 	.analog_2( $signed(analog_1[7:0]) + 9'sd127 ),
@@ -610,6 +619,7 @@ jaguar jaguar_inst
 	.spinner_0(spinner_0),
 	.spinner_1(spinner_1),
 	.spinner_speed(status[21:20]),
+	.team_tap_port2( status[17] ),
 
 	.startcas( startcas ) ,
 

--- a/files_Rework.qip
+++ b/files_Rework.qip
@@ -7,6 +7,7 @@ set_global_assignment -name QIP_FILE           rtl/fx68k/fx68k.qip
 set_global_assignment -name VERILOG_FILE       rtl/nuked-68k/68k.v
 
 set_global_assignment -name VERILOG_FILE       rtl/jag_controller_mux.v
+set_global_assignment -name VERILOG_FILE       rtl/jag_team_tap.v
 set_global_assignment -name VERILOG_FILE       rtl/ps2_mouse.v
 set_global_assignment -name SYSTEMVERILOG_FILE rtl/keyboard.sv
 

--- a/rtl/Rework/jaguar.v
+++ b/rtl/Rework/jaguar.v
@@ -54,6 +54,9 @@ module jaguar
 
 	input       [31:0]  joystick_0,
 	input       [31:0]  joystick_1,
+	input       [31:0]  joystick_2,
+	input       [31:0]  joystick_3,
+	input       [31:0]  joystick_4,
 	input       [7:0]   analog_0,      // Unsigned 0..255 analog input
 	input       [7:0]   analog_1,      // Unsigned 0..255 analog input
 	input       [7:0]   analog_2,      // Unsigned 0..255 analog input
@@ -61,9 +64,9 @@ module jaguar
 	input       [8:0]   spinner_0,
 	input       [8:0]   spinner_1,
 	input       [1:0]   spinner_speed,
+	input               team_tap_port2,
 
 	input       [24:0]  ps2_mouse,
-
 	input               mouse_ena_1,
 	input               mouse_ena_2,
 
@@ -660,8 +663,112 @@ ps2_mouse mouse
 	.button_m(mouseButton_m)    // Active-LOW output!
 );
 
+// Team Tap for Port 2
+wire [5:0] team_tap_port2_row_n;
+wire [3:0] joy2_col_reversed = {u374_reg[4], u374_reg[5], u374_reg[6], u374_reg[7]};
+
+jag_team_tap team_tap_port2_inst (
+	.col_n(~j_xjoy_in[3] ? joy2_col_reversed : 4'b1111),
+	.enable(team_tap_port2),
+	.row_n(team_tap_port2_row_n),
+	
+	// Controller A inputs
+	.but_a_right(joystick_1[0]),
+	.but_a_left(joystick_1[1]),
+	.but_a_down(joystick_1[2]),
+	.but_a_up(joystick_1[3]),
+	.but_a_a(joystick_1[4]),
+	.but_a_b(joystick_1[5]),
+	.but_a_c(joystick_1[6]),
+	.but_a_option(joystick_1[7]),
+	.but_a_pause(joystick_1[8]),
+	.but_a_1(joystick_1[9]),
+	.but_a_2(joystick_1[10]),
+	.but_a_3(joystick_1[11]),
+	.but_a_4(joystick_1[12]),
+	.but_a_5(joystick_1[13]),
+	.but_a_6(joystick_1[14]),
+	.but_a_7(joystick_1[15]),
+	.but_a_8(joystick_1[16]),
+	.but_a_9(joystick_1[17]),
+	.but_a_0(joystick_1[18]),
+	.but_a_star(joystick_1[19]),
+	.but_a_hash(joystick_1[20]),
+	
+	// Controller B inputs
+	.but_b_right(joystick_2[0]),
+	.but_b_left(joystick_2[1]),
+	.but_b_down(joystick_2[2]),
+	.but_b_up(joystick_2[3]),
+	.but_b_a(joystick_2[4]),
+	.but_b_b(joystick_2[5]),
+	.but_b_c(joystick_2[6]),
+	.but_b_option(joystick_2[7]),
+	.but_b_pause(joystick_2[8]),
+	.but_b_1(joystick_2[9]),
+	.but_b_2(joystick_2[10]),
+	.but_b_3(joystick_2[11]),
+	.but_b_4(joystick_2[12]),
+	.but_b_5(joystick_2[13]),
+	.but_b_6(joystick_2[14]),
+	.but_b_7(joystick_2[15]),
+	.but_b_8(joystick_2[16]),
+	.but_b_9(joystick_2[17]),
+	.but_b_0(joystick_2[18]),
+	.but_b_star(joystick_2[19]),
+	.but_b_hash(joystick_2[20]),
+	
+	// Controller C inputs
+	.but_c_right(joystick_3[0]),
+	.but_c_left(joystick_3[1]),
+	.but_c_down(joystick_3[2]),
+	.but_c_up(joystick_3[3]),
+	.but_c_a(joystick_3[4]),
+	.but_c_b(joystick_3[5]),
+	.but_c_c(joystick_3[6]),
+	.but_c_option(joystick_3[7]),
+	.but_c_pause(joystick_3[8]),
+	.but_c_1(joystick_3[9]),
+	.but_c_2(joystick_3[10]),
+	.but_c_3(joystick_3[11]),
+	.but_c_4(joystick_3[12]),
+	.but_c_5(joystick_3[13]),
+	.but_c_6(joystick_3[14]),
+	.but_c_7(joystick_3[15]),
+	.but_c_8(joystick_3[16]),
+	.but_c_9(joystick_3[17]),
+	.but_c_0(joystick_3[18]),
+	.but_c_star(joystick_3[19]),
+	.but_c_hash(joystick_3[20]),
+	
+	// Controller D inputs
+	.but_d_right(joystick_4[0]),
+	.but_d_left(joystick_4[1]),
+	.but_d_down(joystick_4[2]),
+	.but_d_up(joystick_4[3]),
+	.but_d_a(joystick_4[4]),
+	.but_d_b(joystick_4[5]),
+	.but_d_c(joystick_4[6]),
+	.but_d_option(joystick_4[7]),
+	.but_d_pause(joystick_4[8]),
+	.but_d_1(joystick_4[9]),
+	.but_d_2(joystick_4[10]),
+	.but_d_3(joystick_4[11]),
+	.but_d_4(joystick_4[12]),
+	.but_d_5(joystick_4[13]),
+	.but_d_6(joystick_4[14]),
+	.but_d_7(joystick_4[15]),
+	.but_d_8(joystick_4[16]),
+	.but_d_9(joystick_4[17]),
+	.but_d_0(joystick_4[18]),
+	.but_d_star(joystick_4[19]),
+	.but_d_hash(joystick_4[20])
+);
+
+// Standard controller mux instances (used when Team Tap is not active)
 wire [5:0] joy2_row_n;
 wire [5:0] joy1_row_n;
+
 
 jag_controller_mux controller_mux_1
 (
@@ -690,8 +797,6 @@ jag_controller_mux controller_mux_1
 	.but_star   (joystick_0[19]),
 	.but_hash   (joystick_0[20])
 );
-
-wire [3:0] joy2_col_reversed = {u374_reg[4], u374_reg[5], u374_reg[6], u374_reg[7]};
 
 jag_controller_mux controller_mux_2
 (
@@ -810,25 +915,22 @@ end
 assign joy[0] = ee_do;
 assign joy[7:1] = ~j_xjoy_in[3] ? u374_reg[7:1] : 7'b1111_111;      // Port 1, pins 4:2. / Port 2, pins 4:1.
 
+// Select the appropriate row data based on Team Tap configuration
+wire [5:0] selected_joy2_row = team_tap_port2 ? team_tap_port2_row_n : joy2_row_n;
+
 assign joy[8]  = joy1_row_n[5];        // Port 1, pin 14. Mouse XB.
 assign joy[9]  = joy1_row_n[4];        // Port 1, pin 13. Mouse XA.
 assign joy[10] = joy1_row_n[3];        // Port 1, pin 12. Mouse YA / Rotary Encoder XA.
 assign joy[11] = joy1_row_n[2];        // Port 1, pin 11. Mouse YB / Rotary Encoder XB.
-assign b[1]    = joy1_row_n[1];    		// Port 1, pin 10. B1. Mouse Left Button / Rotary Encoder button.
-assign b[0]    = joy1_row_n[0];    		// Port 1, pin 6. BO/Light Pen 0. Mouse Right Button.
+assign b[1]    = joy1_row_n[1];        // Port 1, pin 10. B1. Mouse Left Button / Rotary Encoder button.
+assign b[0]    = joy1_row_n[0];        // Port 1, pin 6. BO/Light Pen 0. Mouse Right Button.
 
-// Standard Jag controller mapping...
-// http://arcarc.xmission.com/Web%20Archives/Deathskull%20%28May-2006%29/games/tech/jagcont.html
-//
-// Mouse / Rotary Encoder hookup info, and test programs...
-// http://mdgames.de/jag_end.htm
-//
-assign joy[12] = joy2_row_n[5];        // Port 2, pin 14.
-assign joy[13] = joy2_row_n[4];        // Port 2, pin 13.
-assign joy[14] = joy2_row_n[3];        // Port 2, pin 12.
-assign joy[15] = joy2_row_n[2];        // Port 2, pin 11.
-assign b[3]    = joy2_row_n[1];    		// Port 2, pin 10. B3.
-assign b[2]    = joy2_row_n[0];    		// Port 2, pin 6. B2/Light Pen 1.
+assign joy[12] = selected_joy2_row[5];        // Port 2, pin 14.
+assign joy[13] = selected_joy2_row[4];        // Port 2, pin 13.
+assign joy[14] = selected_joy2_row[3];        // Port 2, pin 12.
+assign joy[15] = selected_joy2_row[2];        // Port 2, pin 11.
+assign b[3]    = selected_joy2_row[1];        // Port 2, pin 10. B3.
+assign b[2]    = selected_joy2_row[0];        // Port 2, pin 6. B2/Light Pen 1.
 
 assign b[4] = ntsc;             // 0=PAL, 1=NTSC
 assign b[5] = 1'b1;             // 256 (number of columns of the DRAM)

--- a/rtl/Rework/jaguar.v
+++ b/rtl/Rework/jaguar.v
@@ -64,6 +64,7 @@ module jaguar
 	input       [8:0]   spinner_0,
 	input       [8:0]   spinner_1,
 	input       [1:0]   spinner_speed,
+	input               team_tap_port1,
 	input               team_tap_port2,
 
 	input       [24:0]  ps2_mouse,
@@ -663,6 +664,107 @@ ps2_mouse mouse
 	.button_m(mouseButton_m)    // Active-LOW output!
 );
 
+// Team Tap for Port 1
+wire [5:0] team_tap_port1_row_n;
+
+jag_team_tap team_tap_port1_inst (
+	.col_n(~j_xjoy_in[3] ? u374_reg[3:0] : 4'b1111),
+	.enable(team_tap_port1),
+	.row_n(team_tap_port1_row_n),
+	
+	// Controller A inputs
+	.but_a_right(joystick_0[0]),
+	.but_a_left(joystick_0[1]),
+	.but_a_down(joystick_0[2]),
+	.but_a_up(joystick_0[3]),
+	.but_a_a(joystick_0[4]),
+	.but_a_b(joystick_0[5]),
+	.but_a_c(joystick_0[6]),
+	.but_a_option(joystick_0[7]),
+	.but_a_pause(joystick_0[8]),
+	.but_a_1(joystick_0[9]),
+	.but_a_2(joystick_0[10]),
+	.but_a_3(joystick_0[11]),
+	.but_a_4(joystick_0[12]),
+	.but_a_5(joystick_0[13]),
+	.but_a_6(joystick_0[14]),
+	.but_a_7(joystick_0[15]),
+	.but_a_8(joystick_0[16]),
+	.but_a_9(joystick_0[17]),
+	.but_a_0(joystick_0[18]),
+	.but_a_star(joystick_0[19]),
+	.but_a_hash(joystick_0[20]),
+	
+	// Controller B inputs
+	.but_b_right(joystick_1[0]),
+	.but_b_left(joystick_1[1]),
+	.but_b_down(joystick_1[2]),
+	.but_b_up(joystick_1[3]),
+	.but_b_a(joystick_1[4]),
+	.but_b_b(joystick_1[5]),
+	.but_b_c(joystick_1[6]),
+	.but_b_option(joystick_1[7]),
+	.but_b_pause(joystick_1[8]),
+	.but_b_1(joystick_1[9]),
+	.but_b_2(joystick_1[10]),
+	.but_b_3(joystick_1[11]),
+	.but_b_4(joystick_1[12]),
+	.but_b_5(joystick_1[13]),
+	.but_b_6(joystick_1[14]),
+	.but_b_7(joystick_1[15]),
+	.but_b_8(joystick_1[16]),
+	.but_b_9(joystick_1[17]),
+	.but_b_0(joystick_1[18]),
+	.but_b_star(joystick_1[19]),
+	.but_b_hash(joystick_1[20]),
+	
+	// Controller C inputs
+	.but_c_right(joystick_2[0]),
+	.but_c_left(joystick_2[1]),
+	.but_c_down(joystick_2[2]),
+	.but_c_up(joystick_2[3]),
+	.but_c_a(joystick_2[4]),
+	.but_c_b(joystick_2[5]),
+	.but_c_c(joystick_2[6]),
+	.but_c_option(joystick_2[7]),
+	.but_c_pause(joystick_2[8]),
+	.but_c_1(joystick_2[9]),
+	.but_c_2(joystick_2[10]),
+	.but_c_3(joystick_2[11]),
+	.but_c_4(joystick_2[12]),
+	.but_c_5(joystick_2[13]),
+	.but_c_6(joystick_2[14]),
+	.but_c_7(joystick_2[15]),
+	.but_c_8(joystick_2[16]),
+	.but_c_9(joystick_2[17]),
+	.but_c_0(joystick_2[18]),
+	.but_c_star(joystick_2[19]),
+	.but_c_hash(joystick_2[20]),
+	
+	// Controller D inputs
+	.but_d_right(joystick_3[0]),
+	.but_d_left(joystick_3[1]),
+	.but_d_down(joystick_3[2]),
+	.but_d_up(joystick_3[3]),
+	.but_d_a(joystick_3[4]),
+	.but_d_b(joystick_3[5]),
+	.but_d_c(joystick_3[6]),
+	.but_d_option(joystick_3[7]),
+	.but_d_pause(joystick_3[8]),
+	.but_d_1(joystick_3[9]),
+	.but_d_2(joystick_3[10]),
+	.but_d_3(joystick_3[11]),
+	.but_d_4(joystick_3[12]),
+	.but_d_5(joystick_3[13]),
+	.but_d_6(joystick_3[14]),
+	.but_d_7(joystick_3[15]),
+	.but_d_8(joystick_3[16]),
+	.but_d_9(joystick_3[17]),
+	.but_d_0(joystick_3[18]),
+	.but_d_star(joystick_3[19]),
+	.but_d_hash(joystick_3[20])
+);
+
 // Team Tap for Port 2
 wire [5:0] team_tap_port2_row_n;
 wire [3:0] joy2_col_reversed = {u374_reg[4], u374_reg[5], u374_reg[6], u374_reg[7]};
@@ -802,28 +904,27 @@ jag_controller_mux controller_mux_2
 (
 	.col_n      (~j_xjoy_in[3] ? joy2_col_reversed : 4'b1111),
 	.row_n      (joy2_row_n),
-
-	.but_right  ((!mouse_ena_2) ? joystick_1[0] | sp_out1[0] : mouseY[0]),
-	.but_left   ((!mouse_ena_2) ? joystick_1[1] | sp_out1[1] : mouseY[1]),
-	.but_down   ((!mouse_ena_2) ? joystick_1[2] : mouseX[1]),
-	.but_up     ((!mouse_ena_2) ? joystick_1[3] : mouseX[0]),
-	.but_a      ((!mouse_ena_2) ? joystick_1[4] : ~mouseButton_l),
-	.but_b      ((!mouse_ena_2) ? joystick_1[5] : ~mouseButton_m),
-	.but_c      (joystick_1[6]),
-	.but_option (joystick_1[7]),
-	.but_pause  ((!mouse_ena_2) ? joystick_1[8] : ~mouseButton_r),
-	.but_1      (joystick_1[9]),
-	.but_2      (joystick_1[10]),
-	.but_3      (joystick_1[11]),
-	.but_4      (joystick_1[12]),
-	.but_5      (joystick_1[13]),
-	.but_6      (joystick_1[14]),
-	.but_7      (joystick_1[15]),
-	.but_8      (joystick_1[16]),
-	.but_9      (joystick_1[17]),
-	.but_0      (joystick_1[18]),
-	.but_star   (joystick_1[19]),
-	.but_hash   (joystick_1[20])
+	.but_right  ((!mouse_ena_2) ? (team_tap_port1 ? joystick_4[0] : joystick_1[0]) | sp_out1[0] : mouseY[0]),
+	.but_left   ((!mouse_ena_2) ? (team_tap_port1 ? joystick_4[1] : joystick_1[1]) | sp_out1[1] : mouseY[1]),
+	.but_down   ((!mouse_ena_2) ? (team_tap_port1 ? joystick_4[2] : joystick_1[2]) : mouseX[1]),
+	.but_up     ((!mouse_ena_2) ? (team_tap_port1 ? joystick_4[3] : joystick_1[3]) : mouseX[0]),
+	.but_a      ((!mouse_ena_2) ? (team_tap_port1 ? joystick_4[4] : joystick_1[4]) : ~mouseButton_l),
+	.but_b      ((!mouse_ena_2) ? (team_tap_port1 ? joystick_4[5] : joystick_1[5]) : ~mouseButton_m),
+	.but_c      (team_tap_port1 ? joystick_4[6] : joystick_1[6]),
+	.but_option (team_tap_port1 ? joystick_4[7] : joystick_1[7]),
+	.but_pause  ((!mouse_ena_2) ? (team_tap_port2 ? joystick_4[8] : joystick_1[8]) : ~mouseButton_r),
+	.but_1      (team_tap_port1 ? joystick_4[9] : joystick_1[9]),
+	.but_2      (team_tap_port1 ? joystick_4[10] : joystick_1[10]),
+	.but_3      (team_tap_port1 ? joystick_4[11] : joystick_1[11]),
+	.but_4      (team_tap_port1 ? joystick_4[12] : joystick_1[12]),
+	.but_5      (team_tap_port1 ? joystick_4[13] : joystick_1[13]),
+	.but_6      (team_tap_port1 ? joystick_4[14] : joystick_1[14]),
+	.but_7      (team_tap_port1 ? joystick_4[15] : joystick_1[15]),
+	.but_8      (team_tap_port1 ? joystick_4[16] : joystick_1[16]),
+	.but_9      (team_tap_port1 ? joystick_4[17] : joystick_1[17]),
+	.but_0      (team_tap_port1 ? joystick_4[18] : joystick_1[18]),
+	.but_star   (team_tap_port1 ? joystick_4[19] : joystick_1[19]),
+	.but_hash   (team_tap_port1 ? joystick_4[20] : joystick_1[20])
 );
 
 
@@ -916,14 +1017,15 @@ assign joy[0] = ee_do;
 assign joy[7:1] = ~j_xjoy_in[3] ? u374_reg[7:1] : 7'b1111_111;      // Port 1, pins 4:2. / Port 2, pins 4:1.
 
 // Select the appropriate row data based on Team Tap configuration
+wire [5:0] selected_joy1_row = team_tap_port1 ? team_tap_port1_row_n : joy1_row_n;
 wire [5:0] selected_joy2_row = team_tap_port2 ? team_tap_port2_row_n : joy2_row_n;
 
-assign joy[8]  = joy1_row_n[5];        // Port 1, pin 14. Mouse XB.
-assign joy[9]  = joy1_row_n[4];        // Port 1, pin 13. Mouse XA.
-assign joy[10] = joy1_row_n[3];        // Port 1, pin 12. Mouse YA / Rotary Encoder XA.
-assign joy[11] = joy1_row_n[2];        // Port 1, pin 11. Mouse YB / Rotary Encoder XB.
-assign b[1]    = joy1_row_n[1];        // Port 1, pin 10. B1. Mouse Left Button / Rotary Encoder button.
-assign b[0]    = joy1_row_n[0];        // Port 1, pin 6. BO/Light Pen 0. Mouse Right Button.
+assign joy[8]  = selected_joy1_row[5];        // Port 1, pin 14. Mouse XB.
+assign joy[9]  = selected_joy1_row[4];        // Port 1, pin 13. Mouse XA.
+assign joy[10] = selected_joy1_row[3];        // Port 1, pin 12. Mouse YA / Rotary Encoder XA.
+assign joy[11] = selected_joy1_row[2];        // Port 1, pin 11. Mouse YB / Rotary Encoder XB.
+assign b[1]    = selected_joy1_row[1];        // Port 1, pin 10. B1. Mouse Left Button / Rotary Encoder button.
+assign b[0]    = selected_joy1_row[0];        // Port 1, pin 6. BO/Light Pen 0. Mouse Right Button.
 
 assign joy[12] = selected_joy2_row[5];        // Port 2, pin 14.
 assign joy[13] = selected_joy2_row[4];        // Port 2, pin 13.

--- a/rtl/jag_team_tap.v
+++ b/rtl/jag_team_tap.v
@@ -1,0 +1,289 @@
+module tap_controller_mux #(
+    parameter [3:0] P4 = 4'b1110,
+    parameter [3:0] P3 = 4'b1101,
+    parameter [3:0] P2 = 4'b1011,
+    parameter [3:0] P1 = 4'b0111
+) (
+    input  wire [3:0] col_n,
+    output reg  [5:0] row_n,
+    input  wire        but_right,
+    input  wire        but_left,
+    input  wire        but_down,
+    input  wire        but_up,
+    input  wire        but_a,
+    input  wire        but_b,
+    input  wire        but_c,
+    input  wire        but_option,
+    input  wire        but_pause,
+    input  wire        but_1,
+    input  wire        but_2,
+    input  wire        but_3,
+    input  wire        but_4,
+    input  wire        but_5,
+    input  wire        but_6,
+    input  wire        but_7,
+    input  wire        but_8,
+    input  wire        but_9,
+    input  wire        but_0,
+    input  wire        but_star,
+    input  wire        but_hash,
+    // Controller identification signals
+    input  wire        c1_id,      // Controller 1 identification
+    input  wire        c2_id,      // Controller 2 identification  
+    input  wire        c3_id       // Controller 3 identification
+);
+
+always @* begin
+    case (col_n)
+        P4: row_n = ~{ but_up,    but_down, but_left, but_right, but_a,      but_pause };
+        P3: row_n = ~{ but_star,  but_7,    but_4,    but_1,    but_b,      c3_id };
+        P2: row_n = ~{ but_0,     but_8,    but_5,    but_2,    but_c,      c2_id };
+        P1: row_n = ~{ but_hash,  but_9,    but_6,    but_3,    but_option, c1_id };
+        default: row_n = 6'b111111;  // Inactive state when not selected
+    endcase
+end
+
+endmodule
+
+//------------------------------------------------------------------------------
+
+module jag_team_tap (
+    input  wire [3:0] col_n,        // Column select from Jaguar (active low)
+    input  wire       enable,       // Enable signal for Team Tap
+    output wire [5:0] row_n,        // Row data back to Jaguar (active low)
+
+    // Controller A inputs (portA)
+    input but_a_right,
+    input but_a_left,
+    input but_a_down,
+    input but_a_up,
+    input but_a_a,
+    input but_a_b,
+    input but_a_c,
+    input but_a_option,
+    input but_a_pause,
+    input but_a_1,
+    input but_a_2,
+    input but_a_3,
+    input but_a_4,
+    input but_a_5,
+    input but_a_6,
+    input but_a_7,
+    input but_a_8,
+    input but_a_9,
+    input but_a_0,
+    input but_a_star,
+    input but_a_hash,
+
+    // Controller B inputs (portB)
+    input but_b_right,
+    input but_b_left,
+    input but_b_down,
+    input but_b_up,
+    input but_b_a,
+    input but_b_b,
+    input but_b_c,
+    input but_b_option,
+    input but_b_pause,
+    input but_b_1,
+    input but_b_2,
+    input but_b_3,
+    input but_b_4,
+    input but_b_5,
+    input but_b_6,
+    input but_b_7,
+    input but_b_8,
+    input but_b_9,
+    input but_b_0,
+    input but_b_star,
+    input but_b_hash,
+
+    // Controller C inputs (portC)
+    input but_c_right,
+    input but_c_left,
+    input but_c_down,
+    input but_c_up,
+    input but_c_a,
+    input but_c_b,
+    input but_c_c,
+    input but_c_option,
+    input but_c_pause,
+    input but_c_1,
+    input but_c_2,
+    input but_c_3,
+    input but_c_4,
+    input but_c_5,
+    input but_c_6,
+    input but_c_7,
+    input but_c_8,
+    input but_c_9,
+    input but_c_0,
+    input but_c_star,
+    input but_c_hash,
+
+    // Controller D inputs (portD)
+    input but_d_right,
+    input but_d_left,
+    input but_d_down,
+    input but_d_up,
+    input but_d_a,
+    input but_d_b,
+    input but_d_c,
+    input but_d_option,
+    input but_d_pause,
+    input but_d_1,
+    input but_d_2,
+    input but_d_3,
+    input but_d_4,
+    input but_d_5,
+    input but_d_6,
+    input but_d_7,
+    input but_d_8,
+    input but_d_9,
+    input but_d_0,
+    input but_d_star,
+    input but_d_hash
+);
+
+wire [5:0] row_a, row_b, row_c, row_d;
+
+// Instantiate individual controller mux modules for each controller
+tap_controller_mux #(.P4(4'b1110), .P3(4'b1101), .P2(4'b1011), .P1(4'b0111)) controller_a (
+    .col_n(col_n),
+    .row_n(row_a),
+    .but_right(but_a_right),
+    .but_left(but_a_left),
+    .but_down(but_a_down),
+    .but_up(but_a_up),
+    .but_a(but_a_a),
+    .but_b(but_a_b),
+    .but_c(but_a_c),
+    .but_option(but_a_option),
+    .but_pause(but_a_pause),
+    .but_1(but_a_1),
+    .but_2(but_a_2),
+    .but_3(but_a_3),
+    .but_4(but_a_4),
+    .but_5(but_a_5),
+    .but_6(but_a_6),
+    .but_7(but_a_7),
+    .but_8(but_a_8),
+    .but_9(but_a_9),
+    .but_0(but_a_0),
+    .but_star(but_a_star),
+    .but_hash(but_a_hash),
+    .c1_id(1'b0),   // Controller A always responds to C1
+    .c2_id(1'b1),   // Controller A doesn't respond to C2
+    .c3_id(1'b1)    // Controller A doesn't respond to C3
+);
+
+tap_controller_mux #(.P4(4'b0000), .P3(4'b0001), .P2(4'b0010), .P1(4'b0011)) controller_b (
+    .col_n(col_n),
+    .row_n(row_b),
+    .but_right(but_b_right),
+    .but_left(but_b_left),
+    .but_down(but_b_down),
+    .but_up(but_b_up),
+    .but_a(but_b_a),
+    .but_b(but_b_b),
+    .but_c(but_b_c),
+    .but_option(but_b_option),
+    .but_pause(but_b_pause),
+    .but_1(but_b_1),
+    .but_2(but_b_2),
+    .but_3(but_b_3),
+    .but_4(but_b_4),
+    .but_5(but_b_5),
+    .but_6(but_b_6),
+    .but_7(but_b_7),
+    .but_8(but_b_8),
+    .but_9(but_b_9),
+    .but_0(but_b_0),
+    .but_star(but_b_star),
+    .but_hash(but_b_hash),
+    .c1_id(1'b1),   // Controller B doesn't respond to C1
+    .c2_id(1'b0),   // Controller B responds to C2
+    .c3_id(1'b1)    // Controller B doesn't respond to C3
+);
+
+tap_controller_mux #(.P4(4'b0100), .P3(4'b0101), .P2(4'b0110), .P1(4'b1000)) controller_c (
+    .col_n(col_n),
+    .row_n(row_c),
+    .but_right(but_c_right),
+    .but_left(but_c_left),
+    .but_down(but_c_down),
+    .but_up(but_c_up),
+    .but_a(but_c_a),
+    .but_b(but_c_b),
+    .but_c(but_c_c),
+    .but_option(but_c_option),
+    .but_pause(but_c_pause),
+    .but_1(but_c_1),
+    .but_2(but_c_2),
+    .but_3(but_c_3),
+    .but_4(but_c_4),
+    .but_5(but_c_5),
+    .but_6(but_c_6),
+    .but_7(but_c_7),
+    .but_8(but_c_8),
+    .but_9(but_c_9),
+    .but_0(but_c_0),
+    .but_star(but_c_star),
+    .but_hash(but_c_hash),
+    .c1_id(1'b1),   // Controller C doesn't respond to C1
+    .c2_id(1'b1),   // Controller C doesn't respond to C2
+    .c3_id(1'b0)    // Controller C responds to C3
+);
+
+tap_controller_mux #(.P4(4'b1001), .P3(4'b1010), .P2(4'b1100), .P1(4'b1111)) controller_d (
+    .col_n(col_n),
+    .row_n(row_d),
+    .but_right(but_d_right),
+    .but_left(but_d_left),
+    .but_down(but_d_down),
+    .but_up(but_d_up),
+    .but_a(but_d_a),
+    .but_b(but_d_b),
+    .but_c(but_d_c),
+    .but_option(but_d_option),
+    .but_pause(but_d_pause),
+    .but_1(but_d_1),
+    .but_2(but_d_2),
+    .but_3(but_d_3),
+    .but_4(but_d_4),
+    .but_5(but_d_5),
+    .but_6(but_d_6),
+    .but_7(but_d_7),
+    .but_8(but_d_8),
+    .but_9(but_d_9),
+    .but_0(but_d_0),
+    .but_star(but_d_star),
+    .but_hash(but_d_hash),
+    .c1_id(1'b0),   // Controller D responds to C1 (this is key for detection!)
+    .c2_id(1'b1),   // Controller D doesn't respond to C2
+    .c3_id(1'b1)    // Controller D doesn't respond to C3
+);
+
+reg [5:0] selected_row;
+
+always @* begin
+    if (!enable) begin
+        selected_row = 6'b111111;
+    end else begin
+        case (col_n)
+            // Controller A patterns
+            4'b1110, 4'b1101, 4'b1011, 4'b0111: selected_row = row_a;
+            // Controller B patterns  
+            4'b0000, 4'b0001, 4'b0010, 4'b0011: selected_row = row_b;
+            // Controller C patterns
+            4'b0100, 4'b0101, 4'b0110, 4'b1000: selected_row = row_c;
+            // Controller D patterns
+            4'b1001, 4'b1010, 4'b1100, 4'b1111: selected_row = row_d;
+            default: selected_row = 6'b111111;
+        endcase
+    end
+end
+
+assign row_n = selected_row;
+
+endmodule


### PR DESCRIPTION
Team Tap Support

All known compatible software was tested. Gauntlet II, Arena Football 95, Barkley Shut Up and Jam!, NBA Jam, White Men Can't Jump, Super Sprint, Project W, and TeamTap Test ROM.

Notes:
Arena Football 95 works with the Team Tap in either JoyPort. It appears to support two Team Taps, totaling eight players. Support for two Team Taps was not added since MiSTer only supports 6 players, and we get 5 with Team Tap + JoyPort.

Gauntlet II, Super Sprint & Project W require Team Tap to be in JoyPort 1.

Barkley Shut Up and Jam!, NBA Jam & White Men Can't Jump require Team Tap to be in JoyPort 2.

Unrelated:
I removed the JagLink option and always have it wired to the USER port.