### PR TITLE
Use the same serial RX pin as the Gameboy core

### DIFF
--- a/Jaguar.sv
+++ b/Jaguar.sv
@@ -673,7 +673,7 @@ wire [15:0] aud_16_r;
 
 wire ser_data_in;
 wire ser_data_out;
-assign ser_data_in = USER_IN[0];
+assign ser_data_in = USER_IN[2];
 assign USER_OUT[1] = ser_data_out;
 
 wire m68k_clk;


### PR DESCRIPTION
Use the same serial RX pin as the Gameboy core, allowing the use of GB Link cable with GB-SNAC adapters for JagLink.

Tested with all games